### PR TITLE
Make __tileSrcRect optional in enum definition

### DIFF
--- a/src/json_0_8_1.rs
+++ b/src/json_0_8_1.rs
@@ -265,7 +265,7 @@ pub struct EnumValueDefinition {
     /// An array of 4 Int values that refers to the tile in the tileset image: `[ x, y, width,
     /// height ]`
     #[serde(rename = "__tileSrcRect")]
-    pub tile_src_rect: Vec<i64>,
+    pub tile_src_rect: Option<Vec<i64>>,
     /// Enum value
     pub id: String,
     /// The optional ID of the tile


### PR DESCRIPTION
This appears to be an optional field in Ldtk but isn't marked as optional in this library.

I found this by creating an enum in Ldtk, adding it to an entity, and then trying to load it in my rust project. The editor showed no errors but my app crashed when loading the project file. This appears to fix the issue.