### PR TITLE
Added Project::from_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,11 @@ impl Project {
         o
     }
 
+    pub fn from_slice(b: &[u8]) -> Self {
+        let o: Project = serde_json::from_slice(b).expect("error while reading");
+        o
+    }
+
     // Remove any items in the project.levels Vec ... useful when you
     // get external file info and want to replace the items with more
     // complete data extrated from the files.


### PR DESCRIPTION
Like `from_buf()`, but you can feed it a `&[u8]`. Useful for a personal project where I use [rust-embed](https://crates.io/crates/rust-embed) that embeds assets as raw binary data inside the executable.